### PR TITLE
add 'nn' homoglyph for 'm'

### DIFF
--- a/dnstwist.py
+++ b/dnstwist.py
@@ -115,7 +115,7 @@ def bitsquatting(domain):
 def homoglyph(domain):
 	glyphs = {
 	'd':['b', 'cl'], 'm':['n', 'nn', 'rn'], 'l':['1', 'i'], 'o':['0'],
-	'w':['vv'], 'n':['m'], 'b':['d'], 'i':['l'], 'g':['q'], 'q':['g']
+	'w':['vv'], 'n':['m'], 'b':['d'], 'i':['1', 'l'], 'g':['q'], 'q':['g']
 	}
 	out = []
 	dom = domain.rsplit('.', 1)[0]

--- a/dnstwist.py
+++ b/dnstwist.py
@@ -114,7 +114,7 @@ def bitsquatting(domain):
 
 def homoglyph(domain):
 	glyphs = {
-	'd':['b', 'cl'], 'm':['n', 'rn'], 'l':['1', 'i'], 'o':['0'],
+	'd':['b', 'cl'], 'm':['n', 'nn', 'rn'], 'l':['1', 'i'], 'o':['0'],
 	'w':['vv'], 'n':['m'], 'b':['d'], 'i':['l'], 'g':['q'], 'q':['g']
 	}
 	out = []


### PR DESCRIPTION
Adds nn as a homoglyph for m.  Allows dnstwist to detect prennera.com for premera.com, as an example.