### PR TITLE
Add support for lookups against alternate TLD's

### DIFF
--- a/dnstwist.py
+++ b/dnstwist.py
@@ -278,13 +278,22 @@ def fuzz_domain(domain):
 	domains = []
 
 	domains.append({ 'type':'Original*', 'domain':domain })
-	for tld in ['com', 'net', 'org']:
-                dom = domain.rsplit('.', 1)[0]
-                domtld = domain.rsplit('.', 1)[1]
-                if domain.rsplit('.', 1)[1] == tld:
+
+	dom = domain.rsplit('.', 1)[0]
+        domtld = domain.rsplit('.', 1)[1]
+
+        tldset = ['com', 'net', 'org', 'io', 'cm']
+        if not (domtld in tldset):
+                tldset.append(domtld)
+        else:
+                pass
+
+	for tld in tldset:
+                if tld == domtld:
                         pass
                 else:
                         domains.append({ 'type':'TLD Swap', 'domain':dom + '.' + tld })
+                        
                 domain = dom + '.' + tld
                 
                 for i in bitsquatting(domain):

--- a/dnstwist.py
+++ b/dnstwist.py
@@ -278,25 +278,33 @@ def fuzz_domain(domain):
 	domains = []
 
 	domains.append({ 'type':'Original*', 'domain':domain })
-
-	for i in bitsquatting(domain):
-		domains.append({ 'type':'Bitsquatting', 'domain':i })
-	for i in homoglyph(domain):
-		domains.append({ 'type':'Homoglyph', 'domain':i })
-	for i in repetition(domain):
-		domains.append({ 'type':'Repetition', 'domain':i })
-	for i in transposition(domain):
-		domains.append({ 'type':'Transposition', 'domain':i })
-	for i in replacement(domain):
-		domains.append({ 'type':'Replacement', 'domain':i })
-	for i in omission(domain):
-		domains.append({ 'type':'Omission', 'domain':i })
-	for i in hyphenation(domain):
-		domains.append({ 'type':'Hyphenation', 'domain':i })
-	for i in insertion(domain):
-		domains.append({ 'type':'Insertion', 'domain':i })
-	for i in subdomain(domain):
-		domains.append({ 'type':'Subdomain', 'domain':i })
+	for tld in ['com', 'net', 'org']:
+                dom = domain.rsplit('.', 1)[0]
+                domtld = domain.rsplit('.', 1)[1]
+                if domain.rsplit('.', 1)[1] == tld:
+                        pass
+                else:
+                        domains.append({ 'type':'TLD Swap', 'domain':dom + '.' + tld })
+                domain = dom + '.' + tld
+                
+                for i in bitsquatting(domain):
+                        domains.append({ 'type':'Bitsquatting', 'domain':i })
+                for i in homoglyph(domain):
+                        domains.append({ 'type':'Homoglyph', 'domain':i })
+                for i in repetition(domain):
+                        domains.append({ 'type':'Repetition', 'domain':i })
+                for i in transposition(domain):
+                        domains.append({ 'type':'Transposition', 'domain':i })
+                for i in replacement(domain):
+                        domains.append({ 'type':'Replacement', 'domain':i })
+                for i in omission(domain):
+                        domains.append({ 'type':'Omission', 'domain':i })
+                for i in hyphenation(domain):
+                        domains.append({ 'type':'Hyphenation', 'domain':i })
+                for i in insertion(domain):
+                        domains.append({ 'type':'Insertion', 'domain':i })
+                for i in subdomain(domain):
+                        domains.append({ 'type':'Subdomain', 'domain':i })
 
 	domains[:] = [x for x in domains if validate_domain(x['domain'])]
 

--- a/dnstwist.py
+++ b/dnstwist.py
@@ -280,7 +280,7 @@ def fuzz_domain(domain):
 	domains.append({ 'type':'Original*', 'domain':domain })
 
 	dom = domain.rsplit('.', 1)[0]
-        domtld = domain.rsplit('.', 1)[1]
+	domtld = domain.rsplit('.', 1)[1]
 
         tldset = ['com', 'net', 'org', 'io', 'cm']
         if not (domtld in tldset):


### PR DESCRIPTION
Added new typosquatting type of 'TLD Swap' and support for com, net, and org TLDs.  Will create typosquatting variants in each TLD as well as lookup up the base domain name with the swapped TLD.

For example, if example.com is supplied, dnstwist will now look for registrations of example.net and example.org as well as typosquatting variants in each of these alternate TLDs.