### PR TITLE
http_banner ua string and empty list checks

### DIFF
--- a/dnstwist.py
+++ b/dnstwist.py
@@ -325,7 +325,7 @@ def http_banner(ip, vhost):
 		http = socket.socket()
 		http.settimeout(1)
 		http.connect((ip, 80))
-		http.send('HEAD / HTTP/1.1\r\nHost: %s\r\n\r\n' % str(vhost))
+		http.send('HEAD / HTTP/1.1\r\nHost: %s\r\nUser-Agent: Mozilla\\5.0\r\n\r\n' % str(vhost))
 		response = http.recv(1024)
 		http.close()
 	except Exception:

--- a/dnstwist.py
+++ b/dnstwist.py
@@ -339,7 +339,7 @@ def http_banner(ip, vhost):
 				return field[8:]
 		banner = headers[0].split(' ')
 		if len(banner) > 1:
-			return 'HTTP %s' % headers[0].split(' ')[1]
+			return 'HTTP %s' % banner[1]
 
 def smtp_banner(mx):
 	try:

--- a/dnstwist.py
+++ b/dnstwist.py
@@ -337,7 +337,9 @@ def http_banner(ip, vhost):
 		for field in headers:
 			if field.startswith('Server: '):
 				return field[8:]
-		return 'HTTP %s' % headers[0].split(' ')[1]
+		banner = headers[0].split(' ')
+		if len(banner) > 1:
+			return 'HTTP %s' % headers[0].split(' ')[1]
 
 def smtp_banner(mx):
 	try:


### PR DESCRIPTION
wshr.com (54.183.180.82) replied with a zero length response to the HEAD request, causing the program to index into an empty list.

During the fix, I saw that wshr.com responded fine to a regular request and found all it needed was a UA string.