### PR TITLE
Escape commas in country name in CSV format

### DIFF
--- a/dnstwist.py
+++ b/dnstwist.py
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 __author__ = 'Marcin Ulikowski'
-__version__ = '1.0b'
+__version__ = '1.0c'
 __email__ = 'marcin@ulikowski.pl'
 
 import re
@@ -799,7 +799,7 @@ def main():
 			p_out('%s%s%s %s %s\n' % (FG_BLU, domain['fuzzer'].ljust(width_fuzz), FG_RST, domain['domain'].ljust(width_domain), info))
 
 			p_csv(
-			'%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' % (domain.get('fuzzer'), domain.get('domain'), domain.get('a', ''),
+			'%s,%s,%s,%s,%s,%s,"%s",%s,%s,%s\n' % (domain.get('fuzzer'), domain.get('domain'), domain.get('a', ''),
 			domain.get('aaaa', ''), domain.get('mx', ''), domain.get('ns', ''), domain.get('country', ''),
 			domain.get('created', ''), domain.get('updated', ''), str(domain.get('ssdeep', '')))
 			)

--- a/dnstwist.py
+++ b/dnstwist.py
@@ -797,10 +797,14 @@ def main():
 
 		if (args.registered and info != '-') or not args.registered:
 			p_out('%s%s%s %s %s\n' % (FG_BLU, domain['fuzzer'].ljust(width_fuzz), FG_RST, domain['domain'].ljust(width_domain), info))
-
+		
+			country = domain.get('country', '')
+			if ',' in country:
+				country = '"%s"' % country
+		
 			p_csv(
 			'%s,%s,%s,%s,%s,%s,"%s",%s,%s,%s\n' % (domain.get('fuzzer'), domain.get('domain'), domain.get('a', ''),
-			domain.get('aaaa', ''), domain.get('mx', ''), domain.get('ns', ''), domain.get('country', ''),
+			domain.get('aaaa', ''), domain.get('mx', ''), domain.get('ns', ''), country,
 			domain.get('created', ''), domain.get('updated', ''), str(domain.get('ssdeep', '')))
 			)
 

--- a/dnstwist.py
+++ b/dnstwist.py
@@ -803,7 +803,7 @@ def main():
 				country = '"%s"' % country
 		
 			p_csv(
-			'%s,%s,%s,%s,%s,%s,"%s",%s,%s,%s\n' % (domain.get('fuzzer'), domain.get('domain'), domain.get('a', ''),
+			'%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' % (domain.get('fuzzer'), domain.get('domain'), domain.get('a', ''),
 			domain.get('aaaa', ''), domain.get('mx', ''), domain.get('ns', ''), country,
 			domain.get('created', ''), domain.get('updated', ''), str(domain.get('ssdeep', '')))
 			)


### PR DESCRIPTION
Avoid broken CSV formatting when writing country names that include commas, such as "Virgin Islands, British"

See https://en.wikipedia.org/wiki/Comma-separated_values#Basic_rules_and_examples