### PR TITLE
Reorder adding domains to job queue for speedup

### DIFF
--- a/dnstwist.py
+++ b/dnstwist.py
@@ -837,6 +837,9 @@ def main():
 
 	global threads
 	threads = []
+	
+	for i in range(len(domains)):
+		jobs.put(domains[i])
 
 	for i in range(args.threads):
 		worker = DomainThread(jobs)
@@ -864,9 +867,6 @@ def main():
 
 		worker.start()
 		threads.append(worker)
-
-	for i in range(len(domains)):
-		jobs.put(domains[i])
 
 	qperc = 0
 	while not jobs.empty():


### PR DESCRIPTION
Creating the queue and adding the domains to it before creating the jobs performs significantly faster for me than doing it the other way around. I'm not enough of an expert with Python to be sure why this is, but it's possible there's some overhead in adding items to the queue once every thread has a reference to it, which isn't there when you add everything to the queue before assigning jobs to use it.