### PR TITLE
COAL-4225

### DIFF
--- a/dnstwist.py
+++ b/dnstwist.py
@@ -33,6 +33,7 @@ from random import randint
 from os import path
 import smtplib
 import json
+import validators
 
 try:
 	import queue
@@ -114,7 +115,7 @@ else:
 def p_cli(data):
 	global args
 	if args.format == 'cli':
-		sys.stdout.write(data.encode('utf-8'))
+		sys.stdout.write(str(data.encode('utf-8')))
 		sys.stdout.flush()
 
 
@@ -260,10 +261,10 @@ class DomainFuzz():
 		return domain[0] + '.' + domain[1], domain[2]
 
 	def __validate_domain(self, domain):
-		if len(domain) == len(domain.encode('idna')) and domain != domain.encode('idna'):
+		if len(domain) == len(domain.encode('idna')) and domain != domain.encode('idna').decode():
 			return False
 		allowed = re.compile('(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}\.?$)', re.IGNORECASE)
-		return allowed.match(domain.encode('idna'))
+		return allowed.match(domain.encode('idna').decode('ascii'))
 
 	def __filter_domains(self):
 		seen = set()

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,16 +67,6 @@ This is going to install `dnstwist.py` as `dnstwist` only, along with all
 requirements mentioned above. The usage is the same, you can just omit the
 file extension, and the binary will be added to `PATH`.
 
-**Docker**
-
-If you use Docker, you can pull official image from Docker Hub and run it:
-
-```
-$ docker pull elceef/dnstwist
-$ docker run elceef/dnstwist example.com
-```
-
-
 How to use
 ----------
 
@@ -200,16 +190,8 @@ aggressors is unlimited.
 Contact
 -------
 
-To send questions, comments or a chocolate, just drop an e-mail at
-[marcin@ulikowski.pl](mailto:marcin@ulikowski.pl)
+This was ported from the original dnstwist repo, you may be in the wrong place if so, this is focused on making DomainFuzz work in python3, see:
 
-You can also reach the author via:
+https://github.com/elceef/dnstwist
 
-- Twitter: [@elceef](https://twitter.com/elceef)
-- LinkedIn: [Marcin Ulikowski](https://pl.linkedin.com/in/elceef)
-
-Any feedback is appreciated. If you were able to run the tool and you are happy
-with the results just let me know. If you find some confirmed phishing domains
-with `dnstwist` and are comfortable with sharing them, also please send me a
-message. Thank you.
-
+For the original repo


### PR DESCRIPTION
In support of COAL-4225, I've forked the DomainFuzz class within dnstwist to generate a dictionary of names that are appropriate.  The modification is in regards to how Python3 handles idna encoded names and how those are matched to regular expressions for searching.  I ran a few domains of varying sizes to validate this works as expected, currently each result returns the same responses in python2 (original) and python3 (this fork).