### PR TITLE
man page: Fix warning: macro '"' not defined

### DIFF
--- a/docs/dnstwist.1
+++ b/docs/dnstwist.1
@@ -1,4 +1,4 @@
-." Manpage for dnstwist
+.\" Manpage for dnstwist
 .TH DNSTWIST 1 "2020-02-29" "" "User Commands"
 
 .SH NAME


### PR DESCRIPTION
Without this patch I get the following warning:
```
$ LC_ALL=en_US.UTF-8 MANROFFSEQ='' MANWIDTH=80 man --warnings -E UTF-8 -l -Tutf8 -Z dnstwist.1 > /dev/null
troff: <standard input>:1: warning: macro '"' not defined
```