### PR TITLE
Restore import of os.path

### DIFF
--- a/dnstwist.py
+++ b/dnstwist.py
@@ -35,6 +35,7 @@ import signal
 import time
 import argparse
 import threading
+from os import path
 import smtplib
 import json
 import queue


### PR DESCRIPTION
This import has accidentally been removed in 911d262 (Removed randint(),
2020-09-30), but is still required for the dictionary function to work.