### PR TITLE
Added requirements to setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 GeoIP>=1.3.2
 dnspython>=1.14.0
 requests>=2.20.0
-#ssdeep>=3.1
 ppdeep>=20200505
 whois>=0.7
 tld>=0.9.1

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from setuptools import setup
 import dnstwist
 
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
 setup(
 	name='dnstwist',
 	version=dnstwist.__version__,
@@ -18,4 +21,5 @@ setup(
 		'License :: OSI Approved :: Apache Software License',
 		'Operating System :: OS Independent',
 	],
+	install_requires=requirements
 )


### PR DESCRIPTION
I just made a little change to let the users of `dnstwist` version on PyPi to use it without installing the dependencies manually.