### PR TITLE
Do not fail if whois.query returns None

### DIFF
--- a/dnstwist.py
+++ b/dnstwist.py
@@ -949,6 +949,8 @@ def main():
 						p_err(e)
 					pass
 				else:
+					if whoisq is None:
+						continue
 					if whoisq.creation_date:
 						domain['whois-created'] = str(whoisq.creation_date).split(' ')[0]
 					if whoisq.registrar:


### PR DESCRIPTION
This PR adds handling for `None` from `whois.query` (it looks like this is a legit behaviour https://github.com/DannyCork/python-whois/blob/0.9.7/whois/__init__.py#L73)

Originally, the error was caught in one of Homebrew CI runs:

```
==> /usr/local/Cellar/dnstwist/20201022/bin/dnstwist -rsw --thread=1 brew.sh
Traceback (most recent call last):
  File "/usr/local/Cellar/dnstwist/20201022/libexec/bin/dnstwist", line 962, in <module>
    main()
  File "/usr/local/Cellar/dnstwist/20201022/libexec/bin/dnstwist", line 936, in main
    if whoisq.creation_date:
AttributeError: 'NoneType' object has no attribute 'creation_date'
     _           _            _     _
  __| |_ __  ___| |___      _(_)___| |_
 / _` | '_ \/ __| __\ \ /\ / / / __| __|
| (_| | | | \__ \ |_ \ V  V /| \__ \ |_
 \__,_|_| |_|___/\__| \_/\_/ |_|___/\__| {20201022}

Fetching content from: http://brew.sh 200 OK (21.2 Kbytes)
Processing 910 permutations ···········21%···········44%·········64%··············86%······· 7 hits
Querying WHOIS servers ··
```
https://github.com/Homebrew/homebrew-core/pull/66472/checks?check_run_id=1517384199#step:6:3193
