### PR TITLE
Don't print ANSI escape sequences to file on exit

### DIFF
--- a/dnstwist.py
+++ b/dnstwist.py
@@ -767,7 +767,8 @@ def main():
 	parser.add_argument('--debug', action='store_true', help='Display debug messages')
 
 	def _exit(code):
-		print(FG_RST + ST_RST, end='')
+		if sys.stdout.isatty():
+			print(FG_RST + ST_RST, end='')
 		sys.exit(code)
 
 	if len(sys.argv) < 2 or sys.argv[1] in ('-h', '--help'):


### PR DESCRIPTION
Before this change, when using `-o <filename>` you end up with `\x1b[39m\x1b[0m` appended to the end of your file.

There is logic to avoid this elsewhere (by setting `FG_RST`, `ST_RST` etc to empty string) but this happens at module level before the CLI arguments are parsed.

`_exit` is also defined (and used) before the arguments are parsed, which means we can't check `args.output`.

We can safely use `sys.stdout.isatty()` because by the time the `_exit(0)` is called at the end, `sys.stdout` has been overwritten to be the file specified in the `-o` arg, and won't be a tty any more.