### PR TITLE
Explicit use of os module with path.exists method

### DIFF
--- a/dnstwist.py
+++ b/dnstwist.py
@@ -946,14 +946,14 @@ def run(**kwargs):
 
 	dictionary = []
 	if args.dictionary:
-		if not path.exists(args.dictionary):
+		if not os.path.exists(args.dictionary):
 			parser.error('dictionary file not found: %s' % args.dictionary)
 		with open(args.dictionary) as f:
 			dictionary = [x for x in set(f.read().splitlines()) if x.isalnum()]
 
 	tld = []
 	if args.tld:
-		if not path.exists(args.tld):
+		if not os.path.exists(args.tld):
 			parser.error('dictionary file not found: %s' % args.tld)
 		with open(args.tld) as f:
 			tld = [x for x in set(f.read().splitlines()) if re.match(r'^[a-z0-9-]{2,63}(\.[a-z0-9-]{2,63}){0,1}$', x)]


### PR DESCRIPTION
Error message is displayed when used with --tld or -d options (basically when it accesses a file).
> "dnstwist.py", line 956, in run
    if not path.exists(args.tld):
NameError: name 'path' is not defined

I checked the commits to see you updated the import os module (1d1c92685c973c172afd749e4f9a14f7ccb45ee9).
Changed line 949 and 956 to 
```
949 : if not os.path.exists(args.dictionary):
956 : if not os.path.exists(args.tld):
```