### PR TITLE
Updated GeoIP dependency to GeoIP2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-GeoIP>=1.3.2
+GeoIP2>=4.0.0
 dnspython>=1.16.0
 #ssdeep>=3.1
 ppdeep>=20200505


### PR DESCRIPTION
This resolves [this issue](https://pythontechworld.com/issue/elceef/dnstwist/145) by updating the dependency from GeoIP (which has been deprecated since 2014) to GeoIP2