### PR TITLE
Ignore return code on whois

### DIFF
--- a/dnstwist.py
+++ b/dnstwist.py
@@ -1417,7 +1417,7 @@ r'''     _           _            _     _
 			try:
 				_, dom, tld = domain_tld(domain['domain'])
 				with open(os.devnull, 'w') as devnull, contextlib.redirect_stderr(devnull):
-					whoisq = whois.query('.'.join([dom, tld]))
+					whoisq = whois.query('.'.join([dom, tld]), ignore_returncode=True)
 			except Exception as e:
 				_debug(e)
 			else:


### PR DESCRIPTION
The `whois` command uses `getaddrinfo` to perform a domain name resolution on the NIC server. This may cause errors in mistakenly registered domains and cause `whois.query()` to break.

Ignoring the return code allows you to retrieve the previously parsed information. E.g. (on a Rocky Linux 9.1)

```python
>>> import whois
>>> q = whois.query('deamsa.com')
...
whois.exceptions.WhoisCommandFailed: getaddrinfo(https://www.arsys.es/dominios/whois): Name or service not known
...
>>> q = whois.query('deamsa.com', ignore_returncode=True)
>>> q.creation_date
datetime.datetime(2000, 1, 31, 9, 43, 41)
>>> q.registrar
'Arsys Internet, S.L. dba NICLINE.COM'
```



