### PR TITLE
Revises --fuzzers argument docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ venv/
 .idea
 *.pyc
 *.swp
+# VSCode project directory
+.vscode

--- a/dnstwist.py
+++ b/dnstwist.py
@@ -1081,13 +1081,15 @@ def run(**kwargs):
 		'''typosquatting, fraud and brand impersonation.''',
 		formatter_class=lambda prog: argparse.HelpFormatter(prog,max_help_position=30)
 		)
-
+	_default_fuzzers = ['addition', 'bitsquatting', 'cyrillic', 'homoglyph', 'hyphenation',
+			'insertion', 'omission', 'repetition', 'replacement', 'subdomain', 
+			'transposition', 'vowel-swap', 'dictionary', 'tld-swap', 'various']
 	parser.add_argument('domain', help='Domain name or URL to scan')
 	parser.add_argument('-a', '--all', action='store_true', help='Print all DNS records instead of the first ones')
 	parser.add_argument('-b', '--banners', action='store_true', help='Determine HTTP and SMTP service banners')
 	parser.add_argument('-d', '--dictionary', type=str, metavar='FILE', help='Generate more domains using dictionary FILE')
 	parser.add_argument('-f', '--format', type=str, default='cli', help='Output format: cli, csv, json, list (default: cli)')
-	parser.add_argument('--fuzzers', type=str, metavar='LIST', help='Use only selected fuzzing algorithms (separated with commas)')
+	parser.add_argument('--fuzzers', type=str, metavar='LIST', nargs='?', default=', '.join(_default_fuzzers), help='Use only selected fuzzing algorithms (separated with commas).')
 	parser.add_argument('-g', '--geoip', action='store_true', help='Lookup for GeoIP location')
 	parser.add_argument('--lsh', type=str, metavar='LSH', nargs='?', const='ssdeep',
 		help='Evaluate web page similarity with LSH algorithm: ssdeep, tlsh (default: ssdeep)')
@@ -1183,6 +1185,9 @@ def run(**kwargs):
 			parser.error('argument --dictionary cannot be used with selected fuzzing algorithms (consider enabling fuzzer: dictionary)')
 		if args.tld and 'tld-swap' not in fuzzers:
 			parser.error('argument --tld cannot be used with selected fuzzing algorithms (consider enabling fuzzer: tld-swap)')
+	if not args.fuzzers:
+		parser.error('argument --fuzzers requires a comma-separated list of fuzzers.\nAvailable fuzzers: {}'
+	       .format(', '.join(_default_fuzzers)))
 
 	nameservers = []
 	if args.nameservers:


### PR DESCRIPTION
- If used with no arguments, prints available fuzzers
- default fuzzer list matches with generate() function's possible defaults

--- 

Resubmitting with a simpler change. You were right in that I did not originally notice that the `various` and `tld-swap` fuzzers weren't tied to class methods. Since I'm only looking to do a change that affects ease of usage, I just tried to match up the `--fuzzers` argument with how the default fuzzers are used  within the `generate()` function as a preset list.

Original output sample:
```
$ python dnstwist.py --fuzzers --format list contoso.com
usage: dnstwist.py [OPTION]... DOMAIN
dnstwist.py: error: argument --fuzzers: expected one argument
``` 
New output:
```
$ python dnstwist.py --fuzzers --format list contoso.com
usage: dnstwist.py [OPTION]... DOMAIN
dnstwist.py: error: argument --fuzzers requires a comma-separated list of fuzzers.
Available fuzzers: addition, bitsquatting, cyrillic, homoglyph, hyphenation, insertion, omission, repetition, replacement, subdomain, transposition, vowel-swap, dictionary, tld-swap, various
```

I intentionally did not wrap the docstring error output to a specific width, as I didn't see that as a behavior in other parts of the code. However, I found that Python's stdlib has a `textwrap` module going back to 2.7, so if that's something of interest, I will wrap this output appropriately.

Forgive the double PR, I blew up my forked repo and had to resubmit a PR from a clean state.