### PR TITLE
fix: Avoid printing result when not using as CLI

### DIFF
--- a/dnstwist.py
+++ b/dnstwist.py
@@ -1589,11 +1589,11 @@ r'''     _           _            _     _
 
 	if domains:
 		if args.format == 'csv':
-			print(Format(domains).csv())
+			p_cli(Format(domains).csv())
 		elif args.format == 'json':
-			print(Format(domains).json())
+			p_cli(Format(domains).json())
 		elif args.format == 'cli':
-			print(Format(domains).cli())
+			p_cli(Format(domains).cli())
 
 	if hasattr(sys, '_stdout'):
 		sys.stdout = sys._stdout


### PR DESCRIPTION
Avoid printing results to `stdout` when the tool is not being used as a CLI. 

When the tool is used as a lib, it prevents `stdout` from being written unnecessarily since the value is already returned at the end of the execution of `run()` and can be handled appropriately by the function that started the execution.

Before:
```python
>>> import dnstwist
>>> result = dnstwist.run(domain='paypal.com', registered=True, format='json')
[
    {
        "dns_a": [
            "151.101.129.21"
        ],
        "dns_mx": [
            "mx1.paypalcorp.com"
        ],
        "dns_ns": [
            "ns1.p57.dynect.net"
        ],
        ...
        ...
        ...
    }
]
>>> print(result[5].get('domain'))
paypalt.com
```

After:
```python
>>> import dnstwist
>>> result = dnstwist.run(domain='paypal.com', registered=True, format='json')
>>> print(result[5].get('domain'))
paypalt.com
```